### PR TITLE
Modify ZFS commands to work for unprivileged users

### DIFF
--- a/website/source/docs/installation.html.md
+++ b/website/source/docs/installation.html.md
@@ -86,7 +86,7 @@ Flynn uses ZFS for persistent data volumes.  To install ZFS, run these commands:
 $ sudo apt-key adv --keyserver keyserver.ubuntu.com --recv E871F18B51E0147C77796AC81196BA81F6B0FC61
 $ echo deb http://ppa.launchpad.net/zfs-native/stable/ubuntu trusty main | sudo tee /etc/apt/sources.list.d/zfs.list
 $ sudo apt-get update
-$ sudo apt-get install -y ubuntu-zfs
+$ sudo apt-get install ubuntu-zfs
 ```
 
 ### Installation

--- a/website/source/docs/installation.html.md
+++ b/website/source/docs/installation.html.md
@@ -83,9 +83,10 @@ $ sudo apt-get install linux-image-extra-$(uname -r)
 Flynn uses ZFS for persistent data volumes.  To install ZFS, run these commands:
 
 ```
-apt-key adv --keyserver keyserver.ubuntu.com --recv E871F18B51E0147C77796AC81196BA81F6B0FC61
-echo deb http://ppa.launchpad.net/zfs-native/stable/ubuntu trusty main > /etc/apt/sources.list.d/zfs.list
-apt-get install -y ubuntu-zfs
+$ sudo apt-key adv --keyserver keyserver.ubuntu.com --recv E871F18B51E0147C77796AC81196BA81F6B0FC61
+$ echo deb http://ppa.launchpad.net/zfs-native/stable/ubuntu trusty main | sudo tee /etc/apt/sources.list.d/zfs.list
+$ sudo apt-get update
+$ sudo apt-get install -y ubuntu-zfs
 ```
 
 ### Installation


### PR DESCRIPTION
The surrounding shell commands all assume an unprivileged user, and so use `sudo` for any commands that require root access.

This PR modifies the ZFS installation instructions to fit this theme.

Note: I noticed that `apt-get install -y` for ZFS is inconsistent with all of the other `apt-get install`s. If you'd like me to remove the `-y` flag while I'm here, I'd be happy to do so.
